### PR TITLE
Fix exception middleware logging outside bounds

### DIFF
--- a/src/ConsistentApiResponseErrors/Middlewares/ExceptionHandlerMiddleware.cs
+++ b/src/ConsistentApiResponseErrors/Middlewares/ExceptionHandlerMiddleware.cs
@@ -58,7 +58,7 @@ namespace ConsistentApiResponseErrors.Middlewares
                 }
 
                 // Log validation errors with this specific traceID:
-                logger.LogError(exception, exception.Message + " ({traceId})", traceID);
+                logger.LogError(exception, exception.Message + $" ({traceID})");
 
                 //var httpStatusCode = ConfigurateExceptionTypes(exception);
                 var httpStatusCode = apiException.StatusCode;


### PR DESCRIPTION
- **Fix**: Exception middleware "Logging.LogValuesFormatter" Index was outside the bounds of the array.