### PR TITLE
Create a ValidationException to be thrown at runtime

### DIFF
--- a/src/ConsistentApiResponseErrors.Errors/ConsistentErrors/ExceptionError.cs
+++ b/src/ConsistentApiResponseErrors.Errors/ConsistentErrors/ExceptionError.cs
@@ -46,6 +46,15 @@ namespace ConsistentApiResponseErrors.ConsistentErrors
         {
         }
 
+        public ExceptionError()
+        {
+            this.StatusCode = 0;
+            this.StatusMessage = string.Empty;
+            this.ErrorMessage = string.Empty;
+            this.StackTrace = string.Empty;
+            this.TraceId = string.Empty;
+        }
+
         public int StatusCode { get; set; }
         public string StatusMessage { get; set; }
         public string ErrorMessage { get; set; }

--- a/src/ConsistentApiResponseErrors.Errors/ConsistentErrors/ValidationError.cs
+++ b/src/ConsistentApiResponseErrors.Errors/ConsistentErrors/ValidationError.cs
@@ -12,7 +12,15 @@ namespace ConsistentApiResponseErrors.ConsistentErrors
     [Serializable]
     public class ValidationError
     {
-        public ValidationError(List<ValidationFailure> ValidationFailures, string TraceId)
+        public ValidationError()
+        {
+            this.StatusCode = 0;
+            this.StatusMessage = String.Empty;
+            this.TraceId = string.Empty;
+            Errors = new List<Error>();
+        }
+
+        public ValidationError(IList<ValidationFailure> ValidationFailures, string TraceId)
         {
             this.StatusCode = (int)HttpStatusCode.BadRequest;
             this.StatusMessage = HttpStatusCode.BadRequest.ToStringSpaceCamelCase();
@@ -28,7 +36,7 @@ namespace ConsistentApiResponseErrors.ConsistentErrors
         public int StatusCode { get; set; }
         public string StatusMessage { get; set; }
         public string TraceId { get; set; }
-        public List<Error> Errors { get; set; }
+        public IList<Error> Errors { get; set; }
     }
 
 }

--- a/src/ConsistentApiResponseErrors.Errors/Exceptions/ValidationException.cs
+++ b/src/ConsistentApiResponseErrors.Errors/Exceptions/ValidationException.cs
@@ -1,0 +1,99 @@
+﻿using ConsistentApiResponseErrors.ConsistentErrors;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConsistentApiResponseErrors.Exceptions
+{
+    /// <summary>
+    /// ValidationException is used to throw custom validation errors. 
+    /// </summary>
+    [Serializable]
+    public class ValidationException : Exception
+    {
+        public ValidationError ValidationResult { get; private set; }
+        public List<ValidationFailure> ValidationFailures { get; private set; } = new List<ValidationFailure>();
+
+        /// <summary>
+        /// This <see cref="ValidationException"></see> can be thrown based on the <see cref="FluentValidation.Results.ValidationResult"></see> Errors.
+        /// </summary>
+        /// <param name="validationFailures"></param>
+        /// <param name="traceId"></param>
+        public ValidationException(IList<ValidationFailure> validationFailures, string traceId)
+                : base()
+        {
+            ValidationResult = new ValidationError(validationFailures, traceId);
+        }
+
+        /// <summary>
+        /// This <see cref="ValidationException"></see> can be thrown based on the <see cref="FluentValidation.Results.ValidationResult"></see> Errors.
+        /// </summary>
+        /// <param name="errorMessage"></param>
+        /// <param name="validationFailures"></param>
+        /// <param name="traceId"></param>
+        public ValidationException(string errorMessage, IList<ValidationFailure> validationFailures, string traceId)
+            : base(errorMessage)
+        {
+            ValidationResult = new ValidationError(validationFailures, traceId);
+        }
+
+        /// <summary>
+        /// This <see cref="ValidationException"></see> can be thrown based on the <see cref="FluentValidation.Results.ValidationResult"></see> Errors with Exception wrapping.
+        /// </summary>
+        /// <param name="errorMessage"></param>
+        /// <param name="validationFailures"></param>
+        /// <param name="traceId"></param>
+        /// <param name="innerException"></param>
+        public ValidationException(string errorMessage, IList<ValidationFailure> validationFailures, string traceId, Exception innerException)
+            : base(errorMessage, innerException)
+        {
+            ValidationResult = new ValidationError(validationFailures, traceId);
+        }
+
+
+        /// <summary>
+        /// This <see cref="ValidationException"></see> can be thrown based on the ModelState.
+        /// The <c>ModelState.IsValid</c> should be <c>False</c> to use <see cref="ValidationException"></see>.
+        /// </summary>
+        /// <param name="errorMessage">The Exception Error</param>
+        /// <param name="errorCode">e.g. "bad_request"</param>
+        /// <param name="modelStateDictionary"></param>
+        /// <param name="traceId"></param>
+        public ValidationException(string errorMessage, string errorCode, ModelStateDictionary modelStateDictionary, string traceId)
+        : base(errorMessage)
+        {
+            foreach (string modelStateKey in modelStateDictionary.Keys)
+            {
+                var modelState = modelStateDictionary[modelStateKey];
+                if (modelState.Errors.Count <= 0)
+                {
+                    continue;
+                }
+
+                foreach (ModelError modelError in modelState.Errors)
+                {
+                    ValidationFailure validationFailure = new ValidationFailure(modelStateKey, modelError.ErrorMessage, modelState.AttemptedValue);
+                    validationFailure.ErrorCode = errorCode;
+
+                    ValidationFailures.Add(validationFailure);
+                }
+            }
+            ValidationResult = new ValidationError(ValidationFailures, traceId);
+
+        }
+
+        /// <summary>
+        /// This <see cref="ValidationException"></see> can be thrown based on the ModelState.
+        /// The <c>ModelState.IsValid</c> should be <c>False</c> to use <see cref="ValidationException"></see>.
+        /// </summary>
+        /// <param name="errorCode">e.g. "bad_request"</param>
+        /// <param name="modelStateDictionary"></param>
+        /// <param name="traceId"></param>
+        public ValidationException(string errorCode, ModelStateDictionary modelStateDictionary, string traceId) 
+            : this(string.Empty, errorCode, modelStateDictionary, traceId)
+        {
+        }
+    }
+}

--- a/src/ConsistentApiResponseErrors/Filters/ValidateModelStateAttribute.cs
+++ b/src/ConsistentApiResponseErrors/Filters/ValidateModelStateAttribute.cs
@@ -63,22 +63,9 @@ namespace ConsistentApiResponseErrors.Filters
             // Validate the basic model state
             if (!context.ModelState.IsValid)
             {
-                foreach(string modelStateKey in context.ModelState.Keys)
-                {
-                    var modelState = context.ModelState[modelStateKey];
-                    if (modelState.Errors.Count <= 0)
-                    {
-                        continue;
-                    }
-
-                    foreach (ModelError modelError in modelState.Errors)
-                    {
-                        ValidationFailure validationFailure = new ValidationFailure(modelStateKey, modelError.ErrorMessage, modelState.AttemptedValue);
-                        validationFailure.ErrorCode = "bad_request";
-                        
-                        allErrors.Add(validationFailure);
-                    }
-                }
+                // 2020-01-04: Use the "Exceptions.ValidationException" to convert ModelState to Fluent-ValidationFailures
+                Exceptions.ValidationException validationException = new Exceptions.ValidationException("bad_request", context.ModelState, traceId);
+                allErrors.AddRange(validationException.ValidationFailures);
             }
             else if(context.ActionArguments != null)
             {

--- a/tests/Middlewares/ExceptionHandlerMiddleware_Tests.cs
+++ b/tests/Middlewares/ExceptionHandlerMiddleware_Tests.cs
@@ -1,0 +1,227 @@
+﻿using ConsistentApiResponseErrors.ConsistentErrors;
+using ConsistentApiResponseErrors.Exceptions;
+using ConsistentApiResponseErrors.Middlewares;
+using ConsistentApiResponseErrors.xUnit.ApplicationServices.DTOs;
+using ConsistentApiResponseErrors.xUnit.ApplicationServices.Validators;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ConsistentApiResponseErrors.Tests.Middlewares
+{
+    public class ExceptionHandlerMiddleware_Tests
+    {
+        private readonly ILogger<ExceptionHandlerMiddleware> _logger;
+
+        public ExceptionHandlerMiddleware_Tests()
+        {
+            // Show the logs for Debug:
+            IServiceCollection serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder
+                .AddDebug()
+            );
+            var factory = serviceCollection.BuildServiceProvider().GetService<ILoggerFactory>();
+            _logger = factory.CreateLogger<ExceptionHandlerMiddleware>();
+        }
+
+
+
+        /// <summary>
+        /// Scenario:
+        /// An Unexpected Exception is raised.
+        /// </summary>
+        /// 
+        /// Action:
+        /// An <see cref="ExceptionError"></see> will be returned with an InternalServerError HTTP status.
+        /// 
+        [Fact]
+        public async Task WhenAnUnexpectedExceptionIsRaised_AnExceptionErrorWillBeReturned_WithInternalServerErrorHttpStatus()
+        {            
+            // Arrange
+            var thrownException = new Exception("Exception with a parameter: {Param1}");
+            ExceptionError expectedResponse = new ExceptionError(System.Net.HttpStatusCode.InternalServerError, thrownException, string.Empty);
+            var middleware = new ExceptionHandlerMiddleware((innerHttpContext) =>
+            {
+                throw thrownException;
+            }, _logger);
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+
+            //Act
+            await middleware.Invoke(context);
+
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            var reader = new StreamReader(context.Response.Body);
+            var streamText = reader.ReadToEnd();
+            var actualResponse = JsonConvert.DeserializeObject<ExceptionError>(streamText);
+
+            //Assert
+            Assert.Equal(expectedResponse.StatusCode, actualResponse.StatusCode);
+            Assert.Equal(expectedResponse.StatusCode, context.Response.StatusCode);
+            Assert.Equal(expectedResponse.StatusMessage, actualResponse.StatusMessage);
+            Assert.Equal(expectedResponse.ErrorMessage, actualResponse.ErrorMessage);
+        }
+
+
+
+        /// <summary>
+        /// Scenario:
+        /// A Validation Exception based on FluentValidation is raised.
+        /// </summary>
+        /// 
+        /// Action:
+        /// An <see cref="ValidationError"></see> will be returned with an BadRequest HTTP status.
+        /// 
+        [Fact]
+        public async Task WhenAFluentValidationExceptionIsRaised_AValidationErrorWillBeReturned_WithBadRequestHttpStatus()
+        {
+            // Arrange  
+            var requestDTO = new RequestModelBasic() { Id = 0, Message = string.Empty, CreatedOn = DateTime.Now };
+            
+            // Perform a validation using a FluentValidator
+            var validator = new RequestModelBasicValidator();
+            FluentValidation.Results.ValidationResult validationResult = validator.Validate(requestDTO);
+            ValidationException thrownException = new ValidationException(validationResult.Errors, string.Empty);
+            
+            ValidationError expectedResponse = new ValidationError(validationResult.Errors, string.Empty);
+            
+            var middleware = new ExceptionHandlerMiddleware((innerHttpContext) =>
+            {
+                throw thrownException;
+            }, _logger);
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+
+            //Act
+            await middleware.Invoke(context);
+
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            var reader = new StreamReader(context.Response.Body);
+            var streamText = reader.ReadToEnd();
+            var actualResponse = JsonConvert.DeserializeObject<ValidationError>(streamText);
+
+            //Assert
+            Assert.Equal(expectedResponse.StatusCode, actualResponse.StatusCode);
+            Assert.Equal(expectedResponse.StatusCode, context.Response.StatusCode);
+            Assert.Equal(expectedResponse.StatusMessage, actualResponse.StatusMessage);
+            Assert.NotNull(actualResponse.Errors);
+            Assert.Equal(expectedResponse.Errors.Count, actualResponse.Errors.Count);
+
+            for (int i = 0; i < actualResponse.Errors.Count; i++)
+            {
+                Assert.Equal(expectedResponse.Errors[i].Code, actualResponse.Errors[i].Code);
+                Assert.Equal(expectedResponse.Errors[i].Message, actualResponse.Errors[i].Message);
+                Assert.Equal(expectedResponse.Errors[i].AttemptedValue.ToString(), actualResponse.Errors[i].AttemptedValue.ToString());
+                Assert.Equal(expectedResponse.Errors[i].Field, actualResponse.Errors[i].Field);
+            }
+        }
+
+
+
+        /// <summary>
+        /// Scenario:
+        /// A Validation Exception based on ModelState is raised.
+        /// </summary>
+        /// 
+        /// Action:
+        /// An <see cref="ValidationError"></see> will be returned with an BadRequest HTTP status.
+        /// 
+        [Fact]
+        public async Task WhenAModelStateValidationExceptionIsRaised_AValidationErrorWillBeReturned_WithBadRequestHttpStatus()
+        {
+            // Arrange  
+            var requestDTO = new RequestModelBasic() { Id = 0, Message = string.Empty, CreatedOn = DateTime.Now };
+
+            // Perform a validation using ModelState
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("Error_1", "Input string '1.3' is not a valid integer. Path 'userId', line 2, position 17.");
+            modelState["Error_1"].RawValue = "1.3";
+            modelState.AddModelError("Error_2", "Could not convert string to DateTime: 2018:10. Path 'momentsDate', line 4, position 28.");
+            ValidationException thrownException = new ValidationException("bad_request", modelState, string.Empty);
+
+            ValidationError expectedResponse = new ValidationError(thrownException.ValidationFailures, string.Empty);
+
+            var middleware = new ExceptionHandlerMiddleware((innerHttpContext) =>
+            {
+                throw thrownException;
+            }, _logger);
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+
+            //Act
+            await middleware.Invoke(context);
+
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            var reader = new StreamReader(context.Response.Body);
+            var streamText = reader.ReadToEnd();
+            var actualResponse = JsonConvert.DeserializeObject<ValidationError>(streamText);
+
+            //Assert
+            Assert.Equal(expectedResponse.StatusCode, actualResponse.StatusCode);
+            Assert.Equal(expectedResponse.StatusCode, context.Response.StatusCode);
+            Assert.Equal(expectedResponse.StatusMessage, actualResponse.StatusMessage);
+            Assert.NotNull(actualResponse.Errors);
+            Assert.Equal(expectedResponse.Errors.Count, actualResponse.Errors.Count);
+
+            for (int i = 0; i < actualResponse.Errors.Count; i++)
+            {
+                Assert.Equal(expectedResponse.Errors[i].Code, actualResponse.Errors[i].Code);
+                Assert.Equal(expectedResponse.Errors[i].Message, actualResponse.Errors[i].Message);
+                Assert.Equal(expectedResponse.Errors[i].AttemptedValue, actualResponse.Errors[i].AttemptedValue);
+                Assert.Equal(expectedResponse.Errors[i].Field, actualResponse.Errors[i].Field);
+            }
+        }
+
+
+
+        /// <summary>
+        /// Scenario:
+        /// An <see cref="ApiBaseException"/> is raised.
+        /// </summary>
+        /// 
+        /// Action:
+        /// An <see cref="ExceptionError"></see> will be returned with the provided HTTP status.
+        /// 
+        [Fact]
+        public async Task WhenAnApiBaseExceptionIsRaised_AExceptionErrorWillBeReturned_WithAProvidedHttpStatus()
+        {
+            // Arrange  
+            ApiBaseException thrownException = new ApiBaseException(System.Net.HttpStatusCode.GatewayTimeout, "A Test Exception");
+            ExceptionError expectedResponse = new ExceptionError(System.Net.HttpStatusCode.GatewayTimeout, thrownException, string.Empty);
+
+            var middleware = new ExceptionHandlerMiddleware((innerHttpContext) =>
+            {
+                throw thrownException;
+            }, _logger);
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+
+            //Act
+            await middleware.Invoke(context);
+
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            var reader = new StreamReader(context.Response.Body);
+            var streamText = reader.ReadToEnd();
+            var actualResponse = JsonConvert.DeserializeObject<ExceptionError>(streamText);
+
+            //Assert
+            Assert.Equal(expectedResponse.StatusCode, actualResponse.StatusCode);
+            Assert.Equal(expectedResponse.StatusCode, context.Response.StatusCode);
+            Assert.Equal(expectedResponse.StatusMessage, actualResponse.StatusMessage);
+            Assert.Equal(expectedResponse.ErrorMessage, actualResponse.ErrorMessage);
+        }
+
+    }
+}


### PR DESCRIPTION
- **New**: ValidationException is created to be thrown at runtime. It accepts as input either ModelState Errors or FluentValidation Errors.